### PR TITLE
Make block rendering more developer friendly

### DIFF
--- a/lib/hamlbars/template.rb
+++ b/lib/hamlbars/template.rb
@@ -102,7 +102,7 @@ module Haml
       def express(demarcation,expression,options={},&block)
         if block.respond_to? :call
           content = capture_haml(&block)
-          output = "#{demarcation.first}##{make(expression, options)}#{demarcation.last}#{content.strip}#{demarcation.first}/#{expression.split(' ').first}#{demarcation.last}"
+          output = "#{demarcation.first}##{make(expression, options)}#{demarcation.last}\n#{content.strip.gsub(/^/, '  ')}\n#{demarcation.first}/#{expression.split(' ').first}#{demarcation.last}"
         else
           output = "#{demarcation.first}#{make(expression, options)}#{demarcation.last}"
         end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -58,8 +58,27 @@ describe Hamlbars::Template do
 
   it "should render block expressions" do
     expect(to_handlebars("= hb 'hello' do\n  world.")).to eq(
-      "{{#hello}}world.{{/hello}}"
+      "{{#hello}}\n  world.\n{{/hello}}"
     )
+  end
+
+  it "should keep newlines on block expressions" do
+    handlebars = to_handlebars <<EOF
+= hb 'if something' do
+  %div
+    One
+    %div two
+EOF
+    expected = <<EOF
+{{#if something}}
+  <div>
+    One
+    <div>two</div>
+  </div>
+{{/if}}
+EOF
+
+    expect(handlebars).to eq(expected.strip)
   end
 
   it "should render expression options" do
@@ -76,7 +95,7 @@ describe Hamlbars::Template do
 
   it "should render tripple-stash block expressions" do
     expect(to_handlebars("= hb! 'hello' do\n  world.")).to eq(
-      "{{{#hello}}}world.{{{/hello}}}"
+      "{{{#hello}}}\n  world.\n{{{/hello}}}"
     )
   end
 
@@ -92,7 +111,7 @@ describe Hamlbars::Template do
   = hb 'hello'
   %a{:bind => {:href => 'aController'}}
 EOF
-    expect(handlebars).to eq("{{#if a_thing_is_true}}{{hello}}\n<a {{bind-attr href=\"aController\"}}></a>{{/if}}")
+    expect(handlebars).to eq("{{#if a_thing_is_true}}\n  {{hello}}\n<a {{bind-attr href=\"aController\"}}></a>\n{{/if}}")
   end
 
   it "should not mark expressions as html_safe when XSS protection is disabled" do


### PR DESCRIPTION
normal hamlbars:

``` hbs
{{#if messages}}<ul class='alert'>
  {{#each messages}}<li>{{{this}}}</li>{{/each}}
</ul>{{/if}}
```

hamlbars with my modifications:

``` hbs
{{#if messages}}
  <ul class='alert'>
    {{#each messages}}
      <li>{{{this}}}</li>
    {{/each}}
  </ul>
{{/if}}
```
